### PR TITLE
Add dependency on uuid-runtime for DEB packages

### DIFF
--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -14,10 +14,10 @@ graylog-server:
   sha256: "2cbf6fb7115dafe435a012c37e3a2d71469d48d68ee12a7c2efac6f1cca0cfdc"
 
 graylog-collector:
-  version: "0.4.2"
+  version: "0.5.0"
   revision: "1"
   source: "https://packages.graylog2.org/releases/graylog-collector/graylog-collector-#{version}.tgz"
-  sha256: "0e7adc282a6559033cfc9411a2bb0a6c28b95deaae19812a604aacbaff5df757"
+  sha256: "f9e5977c8b223d3ad55d7bb2b7c3108df7c0916f37de51dea383937cd447c67b"
 
 check-graylog2-stream:
   version: "1.2"

--- a/recipes/graylog-server/recipe.rb
+++ b/recipes/graylog-server/recipe.rb
@@ -30,6 +30,7 @@ class GraylogServer < FPM::Cookery::Recipe
     config_files '/etc/default/graylog-server',
                  '/etc/init/graylog-server.conf',
                  '/etc/logrotate.d/graylog-server'
+    depends 'uuid-runtime'
   end
 
   targets :rpm do


### PR DESCRIPTION
Refs Graylog2/graylog2-server#2514

The `uuid-runtime` package is available in basically every major Debian-based distribution:
- https://packages.debian.org/wheezy/uuid-runtime
- https://packages.debian.org/jessie/uuid-runtime
- https://packages.debian.org/stretch/uuid-runtime
- http://packages.ubuntu.com/trusty/uuid-runtime
- http://packages.ubuntu.com/trusty-updates/uuid-runtime
- http://packages.ubuntu.com/xenial/uuid-runtime
