### PR TITLE
Add Omnibus package to list of conflicting packages

### DIFF
--- a/recipes/graylog-server/recipe.rb
+++ b/recipes/graylog-server/recipe.rb
@@ -19,7 +19,7 @@ class GraylogServer < FPM::Cookery::Recipe
   license    data.license
 
   replaces 'graylog2-server'
-  conflicts 'graylog2-web', 'graylog-web'
+  conflicts 'graylog2-web', 'graylog-web', 'graylog'
 
   config_files '/etc/graylog/server/server.conf',
                '/etc/graylog/server/log4j2.xml',


### PR DESCRIPTION
Every now and then people try to "upgrade" the Graylog OVA (using the Graylog Omnibus package) using the regular DEB packages (latest example: https://community.graylog.org/t/upgrade-from-2-2-2-to-2-2-3-still-remain-old-version/760).

This PR adds the Graylog Omnibus package ("graylog") to the list of conflicting packages so that the users will at least receive a more comprehensible error message.