### PR TITLE
Disable repository GPG checks for RPM-based distributions

### DIFF
--- a/recipes/graylog-repository/recipe.rb
+++ b/recipes/graylog-repository/recipe.rb
@@ -57,6 +57,7 @@ class GraylogRepository < FPM::Cookery::Recipe
       file.puts "name=graylog"
       file.puts "baseurl=https://packages.graylog2.org/repo/el/stable/#{VERSION}/$basearch/"
       file.puts "gpgcheck=1"
+      file.puts "repo_gpgcheck=0"
       file.puts "gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-graylog"
     end
 


### PR DESCRIPTION
Refs Graylog2/graylog2-server#4596
Refs https://access.redhat.com/solutions/2850911