### PR TITLE
Avoid fail on systemctl command if not available

### DIFF
--- a/recipes/graylog-server/files/post-install
+++ b/recipes/graylog-server/files/post-install
@@ -49,7 +49,7 @@ fi
 
 if command -v systemctl >/dev/null; then
 	# Reload systemd configuration to make sure the new unit file gets activated
-	systemctl daemon-reload
+	systemctl daemon-reload || true
 fi
 
 if [ "$upgrade" = "true" ]; then


### PR DESCRIPTION
On Debian-based systems, the install scripts are run with set -e meaning that if there is an error in executing one of these scripts then the script fails.
In the following 2 cases it can be a problem:
- The installation is made inside a docker, this means that systemd is not the first pid and is not able to run properly (it will fail)
- The systemd-sysctl is masked and calling it will also make fail the
    installation

This commit changes the situation to return a success code in any case.