### PR TITLE
3.3 build fix

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -7,6 +7,12 @@ RUN yum clean all
 RUN yum install -y rubygems ruby-devel make gcc tar rpm-build curl
 
 # Install the fpm-cookery gem from rubygems.org.
+RUN gem install "rubygems-update:<3.0.0" --no-document
+RUN update_rubygems
+RUN gem install public_suffix -v 2.0.5
+RUN gem install facter -v 2.5.7
+RUN gem install fast_gettext -v 1.1.2
+RUN gem install puppet -v 5.5.19
 RUN gem install fpm-cookery --no-ri --no-rdoc --version 0.25.0
 
 # Remove cached packages and metadata to keep images small.

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -13,6 +13,7 @@ RUN gem install public_suffix -v 2.0.5
 RUN gem install facter -v 2.5.7
 RUN gem install fast_gettext -v 1.1.2
 RUN gem install puppet -v 5.5.19
+RUN gem install ffi -v 1.12.2
 RUN gem install fpm-cookery --no-ri --no-rdoc --version 0.25.0
 
 # Remove cached packages and metadata to keep images small.

--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -2,7 +2,7 @@
 default:
   version_major: "3.3"
   version: "3.3.0"
-  suffix: "-rc.1"
+  suffix: ""
   # Make sure to always increase the revision when doing alpha/beta/rc releases!
   # Example:
   #
@@ -13,7 +13,7 @@ default:
   #   - 2.2.0-alpha.1 => version=2.2.0, revision="1.alpha.1"
   #
   # Only reset the revision once the version is bumped.
-  revision: "4.rc.1"
+  revision: "5"
   homepage: "https://www.graylog.org/"
   maintainer: "Graylog, Inc. <hello@graylog.org>"
   vendor: "graylog"
@@ -21,19 +21,19 @@ default:
 
 graylog-server:
   source: "https://packages.graylog2.org/releases/graylog/graylog-#{version}#{suffix}.tgz"
-  sha256: "8cebc7267d658ea328fea1f8869749c8be7adfbebf40d79a6730e3e033c49556"
+  sha256: "33e07196027fa7dded0d164aba76de05878b39258a18b8882e14bb48c5a3b7f9"
 
 graylog-enterprise-plugins:
   source: "https://packages.graylog2.org/releases/graylog-enterprise/graylog-enterprise-plugins-#{version}#{suffix}.tgz"
-  sha256: "633846e8a811f1471ead3d38252fdc37a73dea067098e09ee41382462425a4ad"
+  sha256: "470e6acf96d15cb2a2fa25bf480e87daca15049c9a02ec8c00058a185156851e"
 
 graylog-integrations-plugins:
   source: "https://packages.graylog2.org/releases/graylog-integrations/graylog-integrations-plugins-#{version}#{suffix}.tgz"
-  sha256: "12159485d432b6f0448780c28589be39ab89f68e671cfc50e7e46bfb28efb45c"
+  sha256: "bd87e3702dac6dfa22797386efa41b2e2394abd7038abc9efee48ac9e3ee9721"
 
 graylog-enterprise-integrations-plugins:
   source: "https://packages.graylog2.org/releases/graylog-enterprise-integrations/graylog-enterprise-integrations-plugins-#{version}#{suffix}.tgz"
-  sha256: "84b7ccfbff1184dc5fe39407b0a667d0cb61df9602afe38a1194c9a444c71574"
+  sha256: "487a01e0057bdc83031029b4b738fb091df65a8ba2f67025a8fbdb1123630091"
 
 graylog-sidecar:
   source: "https://packages.graylog2.org/releases/graylog-collector-sidecar/#{version}/graylog-sidecar-#{version}.tar.gz"

--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -13,7 +13,7 @@ default:
   #   - 2.2.0-alpha.1 => version=2.2.0, revision="1.alpha.1"
   #
   # Only reset the revision once the version is bumped.
-  revision: "1.rc.1"
+  revision: "4.rc.1"
   homepage: "https://www.graylog.org/"
   maintainer: "Graylog, Inc. <hello@graylog.org>"
   vendor: "graylog"

--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -1,7 +1,7 @@
 ---
 default:
   version_major: "3.3"
-  version: "3.3.0"
+  version: "3.3.1"
   suffix: ""
   # Make sure to always increase the revision when doing alpha/beta/rc releases!
   # Example:
@@ -21,19 +21,19 @@ default:
 
 graylog-server:
   source: "https://packages.graylog2.org/releases/graylog/graylog-#{version}#{suffix}.tgz"
-  sha256: "33e07196027fa7dded0d164aba76de05878b39258a18b8882e14bb48c5a3b7f9"
+  sha256: "70b7237f0f06c60c3587d01b400940ff613a3211605f0f02fa6b275271139bc9"
 
 graylog-enterprise-plugins:
   source: "https://packages.graylog2.org/releases/graylog-enterprise/graylog-enterprise-plugins-#{version}#{suffix}.tgz"
-  sha256: "470e6acf96d15cb2a2fa25bf480e87daca15049c9a02ec8c00058a185156851e"
+  sha256: "f9ed400ca2b94fdcfa8d472dc6f4ad26cd043771785ed79f2995cd25e1c0083a"
 
 graylog-integrations-plugins:
   source: "https://packages.graylog2.org/releases/graylog-integrations/graylog-integrations-plugins-#{version}#{suffix}.tgz"
-  sha256: "bd87e3702dac6dfa22797386efa41b2e2394abd7038abc9efee48ac9e3ee9721"
+  sha256: "f84ead24d8422290c2c9b376513972a62dc07b583e66201d6ac9537241c120cd"
 
 graylog-enterprise-integrations-plugins:
   source: "https://packages.graylog2.org/releases/graylog-enterprise-integrations/graylog-enterprise-integrations-plugins-#{version}#{suffix}.tgz"
-  sha256: "487a01e0057bdc83031029b4b738fb091df65a8ba2f67025a8fbdb1123630091"
+  sha256: "9486809456cec0e962710fddc7eb4ecaff5fc20f79e0335ab9792a078b0b4951"
 
 graylog-sidecar:
   source: "https://packages.graylog2.org/releases/graylog-collector-sidecar/#{version}/graylog-sidecar-#{version}.tar.gz"

--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -13,7 +13,7 @@ default:
   #   - 2.2.0-alpha.1 => version=2.2.0, revision="1.alpha.1"
   #
   # Only reset the revision once the version is bumped.
-  revision: "1"
+  revision: "5"
   homepage: "https://www.graylog.org/"
   maintainer: "Graylog, Inc. <hello@graylog.org>"
   vendor: "graylog"

--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -13,7 +13,7 @@ default:
   #   - 2.2.0-alpha.1 => version=2.2.0, revision="1.alpha.1"
   #
   # Only reset the revision once the version is bumped.
-  revision: "5"
+  revision: "1"
   homepage: "https://www.graylog.org/"
   maintainer: "Graylog, Inc. <hello@graylog.org>"
   vendor: "graylog"


### PR DESCRIPTION
When running the build for this repo, I am seeing this error:
```
15:40:58      centos7: Step 11/12 : RUN gem install fpm-cookery --no-ri --no-rdoc --version 0.25.0
15:40:58      centos7:  ---> Running in 9506388d47d1
15:41:03      centos7: ERROR:  Error installing fpm-cookery:
15:41:03      centos7: 	The last version of ffi (>= 0) to support your Ruby & RubyGems was 1.12.2. Try installing it with `gem install ffi -v 1.12.2` and then running the current command again
15:41:03      centos7: 	ffi requires Ruby version >= 2.3. The current ruby version is .
15:41:03      centos7: 
```

Adding the recommended command to the Dockerfile fixes the build.