### PR TITLE
Fix centos7 docker build

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -13,6 +13,7 @@ RUN gem install public_suffix -v 2.0.5
 RUN gem install facter -v 2.5.7
 RUN gem install fast_gettext -v 1.1.2
 RUN gem install puppet -v 5.5.19
+RUN gem install ffi -v 1.12.2
 RUN gem install fpm-cookery --no-ri --no-rdoc --version 0.25.0
 
 # Remove cached packages and metadata to keep images small.


### PR DESCRIPTION
When running the build for this repo, I am seeing this error:

```
15:40:58      centos7: Step 11/12 : RUN gem install fpm-cookery --no-ri --no-rdoc --version 0.25.0
15:40:58      centos7:  ---> Running in 9506388d47d1
15:41:03      centos7: ERROR:  Error installing fpm-cookery:
15:41:03      centos7: 	The last version of ffi (>= 0) to support your Ruby & RubyGems was 1.12.2. Try installing it with `gem install ffi -v 1.12.2` and then running the current command again
15:41:03      centos7: 	ffi requires Ruby version >= 2.3. The current ruby version is .
15:41:03      centos7: 
```
Adding the recommended command to the Dockerfile fixes the build.

Duplicated the error and fix locally and on the Jenkins node.