### PR TITLE
Add log4j2.xml to forwarder package.

### DIFF
--- a/recipes/data.yml
+++ b/recipes/data.yml
@@ -35,11 +35,11 @@ graylog-enterprise-integrations-plugins:
   sha256: 922f3bf5bb717fac8bc671b1a34f23ea7549bca9bed65855e11871505ca5227b
 
 graylog-forwarder:
-  source: https://packages.graylog2.org/releases/cloud/forwarder/3.3.9/graylog-cloud-forwarder-3.3.9-20201030161620.tar.gz
-  sha256: c9777b35196a43ecbaa53775078f2383f33b06b1978ef863a9801266af7496e7
+  source: https://packages.graylog2.org/releases/cloud/forwarder/3.3.9/graylog-cloud-forwarder-3.3.9-20201119163247.tar.gz
+  sha256: f58ce21bfaf1f749c4d20d3071aafeffffe4909af55db77792f92d5982bd5a6a
   version_major: '3.3'
   version: 3.3.9
-  revision: '3'
+  revision: '4'
 
 graylog-sidecar:
   source: https://packages.graylog2.org/releases/graylog-collector-sidecar/#{version}/graylog-sidecar-#{version}.tar.gz

--- a/recipes/graylog-forwarder/files/graylog-forwarder.service
+++ b/recipes/graylog-forwarder/files/graylog-forwarder.service
@@ -16,6 +16,7 @@ WorkingDirectory=/var/lib/graylog-forwarder
 ExecStart=/usr/share/graylog-forwarder/bin/graylog-forwarder run -f /etc/graylog/forwarder/forwarder.conf
 
 Environment="FORWARDER_JVM_OPTIONS_FILE=/etc/graylog/forwarder/jvm.options"
+Environment="JAVA_OPTS=-Dlog4j.configurationFile=file:/etc/graylog/forwarder/log4j2.xml"
 
 # When a JVM receives a SIGTERM signal it exits with 143.
 SuccessExitStatus=143

--- a/recipes/graylog-forwarder/files/graylog-forwarder.service
+++ b/recipes/graylog-forwarder/files/graylog-forwarder.service
@@ -16,7 +16,7 @@ WorkingDirectory=/var/lib/graylog-forwarder
 ExecStart=/usr/share/graylog-forwarder/bin/graylog-forwarder run -f /etc/graylog/forwarder/forwarder.conf
 
 Environment="FORWARDER_JVM_OPTIONS_FILE=/etc/graylog/forwarder/jvm.options"
-Environment="JAVA_OPTS=-Dlog4j.configurationFile=file:/etc/graylog/forwarder/log4j2.xml"
+Environment="JAVA_OPTS=-Dlog4j.configurationFile=file:///etc/graylog/forwarder/log4j2.xml"
 
 # When a JVM receives a SIGTERM signal it exits with 143.
 SuccessExitStatus=143

--- a/recipes/graylog-forwarder/files/log4j2.xml
+++ b/recipes/graylog-forwarder/files/log4j2.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Appenders>
+        <RollingFile name="rolling-file" fileName="/var/log/graylog-forwarder/forwarder.log" filePattern="/var/log/graylog-forwarder/forwarder.log.%i.gz">
+            <PatternLayout pattern="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5p [%c{1}] %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="50MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10" fileIndex="min"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <!-- Application Loggers -->
+        <Logger name="org.graylog2" level="info"/>
+        <Logger name="org.graylog" level="info"/>
+        <Logger name="com.github.joschi.jadconfig" level="warn"/>
+        <!-- Silence Kafka log chatter -->
+        <Logger name="kafka.log.Log" level="warn"/>
+        <Logger name="kafka.log.OffsetIndex" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="rolling-file"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/recipes/graylog-forwarder/files/post-uninstall
+++ b/recipes/graylog-forwarder/files/post-uninstall
@@ -5,6 +5,8 @@ set -e
 user="graylog-forwarder"
 group="graylog-forwarder"
 cfgdir="/etc/graylog/forwarder"
+logdir="/var/log/graylog-forwarder"
+datadir="/var/lib/graylog-forwarder"
 
 remove_data="false"
 
@@ -37,7 +39,7 @@ case "$1" in
 esac
 
 if [ "$remove_data" = "true" ]; then
-	rm -rf "$cfgdir"
+	rm -rf "$datadir" "$cfgdir" "$logdir"
 
 	if id "$user" > /dev/null 2>&1 ; then
 		userdel "$user" || true

--- a/recipes/graylog-forwarder/files/pre-install
+++ b/recipes/graylog-forwarder/files/pre-install
@@ -5,6 +5,7 @@ set -e
 user="graylog-forwarder"
 group="graylog-forwarder"
 datadir="/var/lib/graylog-forwarder"
+logdir="/var/log/graylog-forwarder"
 
 case "$1" in
 	# DEB based systems
@@ -45,5 +46,6 @@ esac
 # Create directories
 install -d -o "$user" -g "$group" -m 0755 "$datadir"
 install -d -o "$user" -g "$group" -m 0755 "$datadir/data"
+install -d -o "$user" -g "$group" -m 0755 "$logdir"
 
 exit 0

--- a/recipes/graylog-forwarder/recipe.rb
+++ b/recipes/graylog-forwarder/recipe.rb
@@ -37,6 +37,7 @@ class GraylogForwarder < FPM::Cookery::Recipe
 
   def install
     etc('graylog/forwarder').install file('forwarder.conf'), 'forwarder.conf'
+    etc('graylog/forwarder').install file('log4j2.xml'), 'log4j2.xml'
     etc('graylog/forwarder').install Dir['config/jvm.options']
 
     share('graylog-forwarder').install 'graylog-cloud-forwarder.jar'


### PR DESCRIPTION
This ensures that users can configure logging via the log4j2.xml file. It also directs logs to a file instead of to the journal by default. 

The log4j2.xml file will exist here:

- /etc/graylog/forwarder/log4j2.xml

By default, logs will be written to a file here:

- /var/log/graylog-forwarder/forwarder.log

