### PR TITLE
Check if CMS GC JAVA_OPTs are available before using them.

### DIFF
--- a/recipes/graylog-server/files/deb/init.d
+++ b/recipes/graylog-server/files/deb/init.d
@@ -46,7 +46,7 @@ if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
 
-# Java versions > 15 don't support CMS Garbage Collector
+# Java versions >= 15 don't support CMS Garbage Collector
 if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
 fi

--- a/recipes/graylog-server/files/deb/init.d
+++ b/recipes/graylog-server/files/deb/init.d
@@ -48,13 +48,7 @@ fi
 
 # Java versions >= 15 don't support CMS Garbage Collector
 if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
-fi
-if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
-fi
-if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
 fi
 
 DAEMON_ARGS="$GRAYLOG_SERVER_JAVA_OPTS $DAEMON_LOG_OPTION -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} -Djava.library.path=/usr/share/graylog-server/lib/sigar -jar $JAR_FILE server -p $PIDFILE -f /etc/graylog/server/server.conf $GRAYLOG_SERVER_ARGS"

--- a/recipes/graylog-server/files/deb/init.d
+++ b/recipes/graylog-server/files/deb/init.d
@@ -45,6 +45,18 @@ DAEMON=${JAVA:=/usr/bin/java}
 if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
+
+# Java versions > 15 don't support CMS Garbage Collector
+if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
+fi
+if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
+fi
+if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+fi
+
 DAEMON_ARGS="$GRAYLOG_SERVER_JAVA_OPTS $DAEMON_LOG_OPTION -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} -Djava.library.path=/usr/share/graylog-server/lib/sigar -jar $JAR_FILE server -p $PIDFILE -f /etc/graylog/server/server.conf $GRAYLOG_SERVER_ARGS"
 
 DAEMON="$GRAYLOG_COMMAND_WRAPPER $DAEMON"

--- a/recipes/graylog-server/files/deb/upstart.conf
+++ b/recipes/graylog-server/files/deb/upstart.conf
@@ -26,15 +26,7 @@ script
 
   # Java versions >= 15 don't support CMS Garbage Collector
   if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
-  fi
-
-  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
-  fi
-
-  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
   fi
 
   exec $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \

--- a/recipes/graylog-server/files/deb/upstart.conf
+++ b/recipes/graylog-server/files/deb/upstart.conf
@@ -24,7 +24,7 @@ script
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
   fi
 
-  # Java versions > 15 don't support CMS Garbage Collector
+  # Java versions >= 15 don't support CMS Garbage Collector
   if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
   fi

--- a/recipes/graylog-server/files/deb/upstart.conf
+++ b/recipes/graylog-server/files/deb/upstart.conf
@@ -24,6 +24,19 @@ script
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
   fi
 
+  # Java versions > 15 don't support CMS Garbage Collector
+  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
+  fi
+
+  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
+  fi
+
+  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+  fi
+
   exec $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
     -Djava.library.path=/usr/share/graylog-server/lib/sigar \

--- a/recipes/graylog-server/files/environment
+++ b/recipes/graylog-server/files/environment
@@ -2,7 +2,7 @@
 JAVA=/usr/bin/java
 
 # Default Java options for heap and garbage collection.
-GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled -XX:-OmitStackTraceInFastThrow"
+GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
 
 # Avoid endless loop with some TLSv1.3 implementations.
 GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -Djdk.tls.acknowledgeCloseNotify=true"

--- a/recipes/graylog-server/files/graylog-server.sh
+++ b/recipes/graylog-server/files/graylog-server.sh
@@ -21,7 +21,7 @@ if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
 
-# Java versions > 15 don't support CMS Garbage Collector
+# Java versions >= 15 don't support CMS Garbage Collector
 if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
 fi

--- a/recipes/graylog-server/files/graylog-server.sh
+++ b/recipes/graylog-server/files/graylog-server.sh
@@ -23,15 +23,7 @@ fi
 
 # Java versions >= 15 don't support CMS Garbage Collector
 if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
-fi
-
-if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
-fi
-
-if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
 fi
 
 $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \

--- a/recipes/graylog-server/files/graylog-server.sh
+++ b/recipes/graylog-server/files/graylog-server.sh
@@ -21,6 +21,19 @@ if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
 
+# Java versions > 15 don't support CMS Garbage Collector
+if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
+fi
+
+if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
+fi
+
+if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+fi
+
 $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
     -Djava.library.path=/usr/share/graylog-server/lib/sigar \

--- a/recipes/graylog-server/files/rpm/init.d
+++ b/recipes/graylog-server/files/rpm/init.d
@@ -58,17 +58,8 @@ fi
 
 # Java versions >= 15 don't support CMS Garbage Collector
 if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
 fi
-
-if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
-fi
-
-if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
-fi
-
 
 start() {
     echo -n $"Starting ${NAME}: "

--- a/recipes/graylog-server/files/rpm/init.d
+++ b/recipes/graylog-server/files/rpm/init.d
@@ -56,6 +56,20 @@ if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
 
+# Java versions > 15 don't support CMS Garbage Collector
+if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
+fi
+
+if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSConcurrentMTEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSConcurrentMTEnabled"
+fi
+
+if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q CMSClassUnloadingEnabled; then
+	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+CMSClassUnloadingEnabled"
+fi
+
+
 start() {
     echo -n $"Starting ${NAME}: "
     install -d -m 755 -o $GRAYLOG_SERVER_USER -g $GRAYLOG_SERVER_USER -d $PID_DIR

--- a/recipes/graylog-server/files/rpm/init.d
+++ b/recipes/graylog-server/files/rpm/init.d
@@ -56,7 +56,7 @@ if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
 fi
 
-# Java versions > 15 don't support CMS Garbage Collector
+# Java versions >= 15 don't support CMS Garbage Collector
 if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
 	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC"
 fi


### PR DESCRIPTION
In order to support Java 15, we need to check whether the JAVA_OPTs for the CMS Garbage Collector are available or not. 

Related to: Graylog2/graylog2-server#10275

I copied the structure of #87 to see which changes needed to be made. 