### PR TITLE
Add scripts/ dir and integrations_scripts_dir config.

### DIFF
--- a/recipes/graylog-enterprise/patches/graylog-server.conf.patch2
+++ b/recipes/graylog-enterprise/patches/graylog-server.conf.patch2
@@ -5,5 +5,5 @@
  # Default: TLSv1.2,TLSv1.3  (might be automatically adjusted to protocols supported by the JDK)
  #enabled_tls_protocols= TLSv1.2,TLSv1.3
 +
-+# An absolute or relative path where scripts are permitted to be executed from.
++# An absolute path where scripts are permitted to be executed from.
 +integrations_scripts_dir = /usr/share/graylog-server/scripts

--- a/recipes/graylog-enterprise/patches/graylog-server.conf.patch2
+++ b/recipes/graylog-enterprise/patches/graylog-server.conf.patch2
@@ -1,0 +1,9 @@
+--- graylog.conf.example        2021-03-31 10:00:49.785429250 -0500
++++ graylog.conf        2021-03-31 10:00:40.693473340 -0500
+@@ -686,3 +686,6 @@
+ # Setting this to an empty value, leaves it up to system libraries and the used JDK to chose a default.
+ # Default: TLSv1.2,TLSv1.3  (might be automatically adjusted to protocols supported by the JDK)
+ #enabled_tls_protocols= TLSv1.2,TLSv1.3
++
++# An absolute or relative path where scripts are permitted to be executed from.
++integrations_scripts_dir = /usr/share/graylog-server/scripts

--- a/recipes/graylog-enterprise/recipe.rb
+++ b/recipes/graylog-enterprise/recipe.rb
@@ -47,6 +47,7 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
 
   def build
     patch(workdir('../graylog-server/patches/graylog-server.conf.patch'))
+    patch(workdir('patches/graylog-server.conf.patch2'))
   end
 
   def install
@@ -79,6 +80,9 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
     share('graylog-server/bin').install 'bin/chromedriver'
     share('graylog-server/bin').install 'bin/chromedriver_start.sh'
     share('graylog-server/bin').install 'bin/headless_shell'
+
+    share('graylog-server/scripts').mkdir
+    share('graylog-server/scripts').chmod(0755)
 
     # Remove unused sigar libs.
     sigar_cleanup(share('graylog-server/lib/sigar'))


### PR DESCRIPTION
This adds a bit of automated setup for people using scripts in notifications. 

- Add the `/usr/share/graylog-server/scripts` directory
- Add the `integrations_scripts_dir` property to `/etc/graylog/server/server.conf`

Fixes #106 