### PR TITLE
Remove unneeded chain_cert_file prop

### DIFF
--- a/recipes/graylog-forwarder/files/forwarder.conf
+++ b/recipes/graylog-forwarder/files/forwarder.conf
@@ -1,5 +1,4 @@
 forwarder_server_hostname =
-forwarder_grpc_tls_trust_chain_cert_file =
 forwarder_grpc_api_token =
 
 bin_dir = /usr/share/graylog-forwarder/bin


### PR DESCRIPTION
The `forwarder_grpc_tls_trust_chain_cert_file` `forwarder.conf` property is no longer needed for production Cloud setups, since they now rely on a CA. If specified in `forwarder.conf`, it will cause the Forwarder to try and validate it. So, removing it here helps to avoid the error. 

Making this change here avoids the error in new Forwarder OS package and Docker installations.

See https://github.com/Graylog2/graylog-cloud/issues/1081 for an example of customer-specific Forwarder values with the cert omitted.