### PR TITLE
Update "replaces" metadata for 4.2

### DIFF
--- a/recipes/graylog-repository/recipe.rb
+++ b/recipes/graylog-repository/recipe.rb
@@ -9,7 +9,7 @@ class GraylogRepository < FPM::Cookery::Recipe
 
   name       "graylog-#{VERSION}-repository"
   version    '1'
-  revision   3
+  revision   4
   source     '', :with => :noop
   arch       'all'
   homepage   data.homepage
@@ -21,7 +21,7 @@ class GraylogRepository < FPM::Cookery::Recipe
     "graylog2-#{v}-repository-#{os}#{osrel}"
   }.concat(%w(1.0 1.1 1.2 1.3).map {|v|
     "graylog-#{v}-repository-#{os}#{osrel}"
-  }).concat(%w(2.0 2.1 2.2 2.3 2.4 2.5 3.0 3.1 3.2 3.3 4.0).map {|v|
+  }).concat(%w(2.0 2.1 2.2 2.3 2.4 2.5 3.0 3.1 3.2 3.3 4.0 4.1).map {|v|
     "graylog-#{v}-repository"
   })
 


### PR DESCRIPTION
I wonder if we shouldn't automate this somehow..


