### PR TITLE
Fixes for log4j CVE-2021-44228

### DIFF
--- a/recipes/graylog-server/files/environment
+++ b/recipes/graylog-server/files/environment
@@ -7,6 +7,9 @@ GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -
 # Avoid endless loop with some TLSv1.3 implementations.
 GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -Djdk.tls.acknowledgeCloseNotify=true"
 
+# Fix for log4j CVE-2021-44228
+GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -Dlog4j2.formatMsgNoLookups=true"
+
 # Pass some extra args to graylog-server. (i.e. "-d" to enable debug mode)
 GRAYLOG_SERVER_ARGS=""
 


### PR DESCRIPTION
 - Configure log4j2.formatMsgNoLookups=true by default

Details: https://logging.apache.org/log4j/2.x/security.html
(cherry picked from commit 6ba0069951d0ffa84cb385e338f65157bea7c928)

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

