### PR TITLE
Add arch-specific chromedriver to enterprise packages.

### DIFF
--- a/recipes/graylog-enterprise-plugins/recipe.rb
+++ b/recipes/graylog-enterprise-plugins/recipe.rb
@@ -31,13 +31,9 @@ class GraylogEnterprisePlugins < FPM::Cookery::Recipe
   end
 
   def install
-    share('graylog-server').install 'bin'
-    # Install all binaries except the architecture specific ones.
-    share('graylog-server/bin').install Dir['bin/*'].reject {|f| f =~ /\.(amd64|arm64)$/ }
-
-    # Install the architecture specific binaries
-    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", 'chromedriver'
-    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", 'headless_shell'
+    share('graylog-server/bin').install 'bin/chromedriver_start.sh'
+    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", "chromedriver_#{pkg_arch}"
+    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", "headless_shell_#{pkg_arch}"
 
     share('graylog-server').install 'plugin'
     share('graylog-server/plugin').install 'LICENSE', 'LICENSE-ENTERPRISE'

--- a/recipes/graylog-enterprise-plugins/recipe.rb
+++ b/recipes/graylog-enterprise-plugins/recipe.rb
@@ -9,7 +9,7 @@ class GraylogEnterprisePlugins < FPM::Cookery::Recipe
   version  data.version
   revision data.revision
   homepage data.homepage
-  arch     'all'
+  arch     pkg_arch
 
   source data.source
   sha256 data.sha256
@@ -32,7 +32,12 @@ class GraylogEnterprisePlugins < FPM::Cookery::Recipe
 
   def install
     share('graylog-server').install 'bin'
-    share('graylog-server/bin').install Dir['bin/*']
+    # Install all binaries except the architecture specific ones.
+    share('graylog-server/bin').install Dir['bin/*'].reject {|f| f =~ /\.(amd64|arm64)$/ }
+
+    # Install the architecture specific binaries
+    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", 'chromedriver'
+    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", 'headless_shell'
 
     share('graylog-server').install 'plugin'
     share('graylog-server/plugin').install 'LICENSE', 'LICENSE-ENTERPRISE'

--- a/recipes/graylog-enterprise/recipe.rb
+++ b/recipes/graylog-enterprise/recipe.rb
@@ -77,10 +77,8 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
 
     share('graylog-server').install 'LICENSE'
     share('graylog-server/bin').install 'bin/chromedriver_start.sh'
-    
-    # Install the architecture specific binaries
-    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", 'chromedriver'
-    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", 'headless_shell'
+    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", "chromedriver_#{pkg_arch}"
+    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", "headless_shell_#{pkg_arch}"
 
     share('graylog-server/scripts').mkdir
     share('graylog-server/scripts').chmod(0755)

--- a/recipes/graylog-enterprise/recipe.rb
+++ b/recipes/graylog-enterprise/recipe.rb
@@ -9,7 +9,7 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
   version  data.version
   revision data.revision
   homepage data.homepage
-  arch     'all'
+  arch     pkg_arch
 
   source data.source
   sha256 data.sha256
@@ -76,9 +76,11 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
     share('graylog-server').install 'plugin'
 
     share('graylog-server').install 'LICENSE'
-    share('graylog-server/bin').install 'bin/chromedriver'
     share('graylog-server/bin').install 'bin/chromedriver_start.sh'
-    share('graylog-server/bin').install 'bin/headless_shell'
+    
+    # Install the architecture specific binaries
+    share('graylog-server/bin').install "bin/chromedriver_#{pkg_arch}", 'chromedriver'
+    share('graylog-server/bin').install "bin/headless_shell_#{pkg_arch}", 'headless_shell'
 
     share('graylog-server/scripts').mkdir
     share('graylog-server/scripts').chmod(0755)

--- a/recipes/tools.rb
+++ b/recipes/tools.rb
@@ -53,6 +53,14 @@ module Tools
         end
       end
     end
+
+    def pkg_arch
+      ENV['PKG_ARCH'] || 'all'
+    end
+  end
+
+  def pkg_arch
+    self.class.pkg_arch
   end
 
   def fact(key)


### PR DESCRIPTION
Adding architecture-specific `chromedriver` and `headless_shell` into enterprise packages. 

See: https://github.com/Graylog2/ci-infrastructure/issues/27


