### PR TITLE
Use G1GC by default

### DIFF
--- a/recipes/graylog-server/files/deb/init.d
+++ b/recipes/graylog-server/files/deb/init.d
@@ -41,16 +41,6 @@ DAEMON=${JAVA:=/usr/bin/java}
 
 [ -x "$DAEMON" ] || exit 0
 
-# Java versions > 8 don't support UseParNewGC
-if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
-fi
-
-# Java versions >= 15 don't support CMS Garbage Collector
-if "$DAEMON" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
-fi
-
 DAEMON_ARGS="$GRAYLOG_SERVER_JAVA_OPTS $DAEMON_LOG_OPTION -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} -Djava.library.path=/usr/share/graylog-server/lib/sigar -jar $JAR_FILE server -p $PIDFILE -f /etc/graylog/server/server.conf $GRAYLOG_SERVER_ARGS"
 
 DAEMON="$GRAYLOG_COMMAND_WRAPPER $DAEMON"

--- a/recipes/graylog-server/files/deb/upstart.conf
+++ b/recipes/graylog-server/files/deb/upstart.conf
@@ -19,16 +19,6 @@ script
     . "/usr/share/graylog-server/installation-source.sh"
   fi
 
-  # Java versions > 8 don't support UseParNewGC
-  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
-  fi
-
-  # Java versions >= 15 don't support CMS Garbage Collector
-  if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
-  fi
-
   exec $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
     -Djava.library.path=/usr/share/graylog-server/lib/sigar \

--- a/recipes/graylog-server/files/environment
+++ b/recipes/graylog-server/files/environment
@@ -2,7 +2,7 @@
 JAVA=/usr/bin/java
 
 # Default Java options for heap and garbage collection.
-GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx1g -XX:NewRatio=1 -server -XX:+ResizeTLAB -XX:-OmitStackTraceInFastThrow"
+GRAYLOG_SERVER_JAVA_OPTS="-Xms1g -Xmx1g -server -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow"
 
 # Avoid endless loop with some TLSv1.3 implementations.
 GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -Djdk.tls.acknowledgeCloseNotify=true"

--- a/recipes/graylog-server/files/graylog-server.sh
+++ b/recipes/graylog-server/files/graylog-server.sh
@@ -16,16 +16,6 @@ if [ -f "/usr/share/graylog-server/installation-source.sh" ]; then
     . "/usr/share/graylog-server/installation-source.sh"
 fi
 
-# Java versions > 8 don't support UseParNewGC
-if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
-fi
-
-# Java versions >= 15 don't support CMS Garbage Collector
-if ${JAVA:=/usr/bin/java} -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
-fi
-
 $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
     -Djava.library.path=/usr/share/graylog-server/lib/sigar \

--- a/recipes/graylog-server/files/rpm/init.d
+++ b/recipes/graylog-server/files/rpm/init.d
@@ -35,11 +35,11 @@ JAR_FILE=/usr/share/graylog-server/graylog.jar
 JAVA=/usr/bin/java
 PID_DIR=/var/run/graylog-server
 PID_FILE=$PID_DIR/$NAME.pid
-JAVA_ARGS="-jar -Djava.library.path=/usr/share/graylog-server/lib/sigar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} $JAR_FILE server -p $PID_FILE -f /etc/graylog/server/server.conf"
+JAVA_ARGS="-jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} $JAR_FILE server -p $PID_FILE -f /etc/graylog/server/server.conf"
 SCRIPTNAME=/etc/init.d/$NAME
 LOCKFILE=/var/lock/subsys/$NAME
 GRAYLOG_SERVER_USER=graylog
-GRAYLOG_SERVER_JAVA_OPTS=""
+GRAYLOG_SERVER_JAVA_OPTS="-XX:+UseG1GC"
 # Pull in sysconfig settings
 [ -f /etc/sysconfig/${NAME} ] && . /etc/sysconfig/${NAME}
 
@@ -49,16 +49,6 @@ GRAYLOG_SERVER_JAVA_OPTS=""
 
 if [ -f "/usr/share/graylog-server/installation-source.sh" ]; then
     . "/usr/share/graylog-server/installation-source.sh"
-fi
-
-# Java versions > 8 don't support UseParNewGC
-if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseParNewGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseParNewGC"
-fi
-
-# Java versions >= 15 don't support CMS Garbage Collector
-if "$JAVA" -XX:+PrintFlagsFinal 2>&1 | grep -q UseConcMarkSweepGC; then
-	GRAYLOG_SERVER_JAVA_OPTS="$GRAYLOG_SERVER_JAVA_OPTS -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:+CMSClassUnloadingEnabled"
 fi
 
 start() {


### PR DESCRIPTION
There are some cases where Java falls back to using the Serial GC instead of G1GC: Less then 2GB of RAM or only one CPU. This can be the case in some docker environments.
We always want to use G1GC, because it ensures that GC pauses are always short.

https://github.com/openjdk/jdk/blob/3121898c33fa3cc5a049977f8677105a84c3e50c/src/hotspot/share/runtime/os.cpp#L1673

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

