### PR TITLE
Add AmbientCapabilities=CAP_NET_BIND_SERVICE to systemd service

### DIFF
--- a/recipes/graylog-server/files/systemd.service
+++ b/recipes/graylog-server/files/systemd.service
@@ -11,6 +11,7 @@ RestartSec=10
 User=graylog
 Group=graylog
 LimitNOFILE=64000
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 ExecStart=/usr/share/graylog-server/bin/graylog-server
 


### PR DESCRIPTION
For https://github.com/Graylog2/graylog2-server/issues/14867

Users cannot bind to ports <1024 without this setting. Its much more common place to configure HTTPS/TLS which would require binding to TCP 443. This will save our users a lot of trouble.

Additionally, if a user does manually add this to their systemd service file, the file will be ovewritten when the package applies an update leading to unexpected failures.

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

