### PR TITLE
Remove obsolete sigar cleanup and Java opts settings

### DIFF
--- a/recipes/graylog-server/files/deb/init.d
+++ b/recipes/graylog-server/files/deb/init.d
@@ -41,7 +41,7 @@ DAEMON=${JAVA:=/usr/bin/java}
 
 [ -x "$DAEMON" ] || exit 0
 
-DAEMON_ARGS="$GRAYLOG_SERVER_JAVA_OPTS $DAEMON_LOG_OPTION -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} -Djava.library.path=/usr/share/graylog-server/lib/sigar -jar $JAR_FILE server -p $PIDFILE -f /etc/graylog/server/server.conf $GRAYLOG_SERVER_ARGS"
+DAEMON_ARGS="$GRAYLOG_SERVER_JAVA_OPTS $DAEMON_LOG_OPTION -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} -jar $JAR_FILE server -p $PIDFILE -f /etc/graylog/server/server.conf $GRAYLOG_SERVER_ARGS"
 
 DAEMON="$GRAYLOG_COMMAND_WRAPPER $DAEMON"
 

--- a/recipes/graylog-server/files/deb/upstart.conf
+++ b/recipes/graylog-server/files/deb/upstart.conf
@@ -21,7 +21,6 @@ script
 
   exec $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
-    -Djava.library.path=/usr/share/graylog-server/lib/sigar \
     -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} \
     /usr/share/graylog-server/graylog.jar server -f /etc/graylog/server/server.conf -np \
     $GRAYLOG_SERVER_ARGS

--- a/recipes/graylog-server/files/graylog-server.sh
+++ b/recipes/graylog-server/files/graylog-server.sh
@@ -22,7 +22,6 @@ fi
 
 $GRAYLOG_COMMAND_WRAPPER ${JAVA:=/usr/bin/java} $GRAYLOG_SERVER_JAVA_OPTS \
     -jar -Dlog4j.configurationFile=file:///etc/graylog/server/log4j2.xml \
-    -Djava.library.path=/usr/share/graylog-server/lib/sigar \
     -Dgraylog2.installation_source=${GRAYLOG_INSTALLATION_SOURCE:=unknown} \
     /usr/share/graylog-server/graylog.jar server -f /etc/graylog/server/server.conf -np \
     $GRAYLOG_SERVER_ARGS

--- a/recipes/tools.rb
+++ b/recipes/tools.rb
@@ -39,22 +39,6 @@ module Tools
        end
     end
 
-    def sigar_cleanup(path)
-      Dir["#{path}/*"].each do |file|
-        unless file.end_with?('.so')
-          FileUtils.rm(file)
-        end
-
-        if file =~ /freebsd|aix|solaris/
-          FileUtils.rm(file)
-        end
-
-        if file =~ /(ppc.*|ia64|s390x)-linux/
-          FileUtils.rm(file)
-        end
-      end
-    end
-
     def pkg_arch
       ENV['PKG_ARCH'] || 'all'
     end
@@ -87,10 +71,6 @@ module Tools
 
   def osrel
     self.class.osrel
-  end
-
-  def sigar_cleanup(path)
-    self.class.sigar_cleanup(path)
   end
 
   def osfile(name)


### PR DESCRIPTION
We don't use the sigar library anymore, so we can remove the "java.library.path" setting that supported its usage.

Also, remove unused sigar cleanup functions in tools.rb.
