### PR TITLE
Exclude library files in /var/lib/graylog-server/ from needrestart(1)

### DIFF
--- a/recipes/graylog-enterprise/recipe.rb
+++ b/recipes/graylog-enterprise/recipe.rb
@@ -70,6 +70,8 @@ class GraylogEnterpriseServer < FPM::Cookery::Recipe
     etc('init.d').install file("#{target}/init.d"), 'graylog-server'
     etc('init.d/graylog-server').chmod(0755)
 
+    etc('needrestart/conf.d').install file('needrestart.conf'), '500-graylog.conf'
+
     lib('systemd/system').install file('systemd.service'), 'graylog-server.service'
 
     share('graylog-server/bin').install file('graylog-server.sh'), 'graylog-server'

--- a/recipes/graylog-server/files/needrestart.conf
+++ b/recipes/graylog-server/files/needrestart.conf
@@ -1,0 +1,3 @@
+# Avoid triggering needrestart(1) for library files in the Graylog data
+# directory. Graylog writes native libraries to that directory at runtime.
+push @{$nrconf{blacklist_mappings}}, qr(^/var/lib/graylog-server/);

--- a/recipes/graylog-server/recipe.rb
+++ b/recipes/graylog-server/recipe.rb
@@ -68,6 +68,8 @@ class GraylogServer < FPM::Cookery::Recipe
     etc('init.d').install file("#{target}/init.d"), 'graylog-server'
     etc('init.d/graylog-server').chmod(0755)
 
+    etc('needrestart/conf.d').install file('needrestart.conf'), '500-graylog.conf'
+
     lib('systemd/system').install file('systemd.service'), 'graylog-server.service'
 
     share('graylog-server/bin').install file('graylog-server.sh'), 'graylog-server'


### PR DESCRIPTION
The library files are written by the JVM at runtime and shouldn't trigger needrestart(1).

Fixes Graylog2/graylog2-server#20949
