### PR TITLE
Fix multi_json version to ensure ruby 2 support

### DIFF
--- a/docker/alma9/Dockerfile
+++ b/docker/alma9/Dockerfile
@@ -5,5 +5,6 @@ MAINTAINER Graylog, Inc. <hello@graylog.com>
 RUN yum install -y --allowerasing rubygems ruby-devel make gcc tar rpm-build curl git && \
     gem install dotenv -v 2.8.1 --no-document && \
     gem install public_suffix -v 5.1.1 --no-document && \
+    gem install multi_json -v 1.15.0 && \
     gem install fpm-cookery -v 0.37.0 --no-document && \
     yum clean all

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -7,5 +7,6 @@ RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|
 
 RUN yum install -y rubygems ruby-devel make gcc tar rpm-build curl git && \
     gem install dotenv -v 2.8.1 --no-document && \
+    gem install multi_json -v 1.15.0 && \
     gem install fpm-cookery -v 0.35.1 --no-document && \
     yum clean all

--- a/docker/ubuntu2004/Dockerfile
+++ b/docker/ubuntu2004/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && \
     apt-get install -y ruby ruby2.7 ruby2.7-dev build-essential curl lsb-release git && \
     gem install dotenv -v 2.8.1 --no-document && \
     gem install public_suffix -v 5.1.1 --no-document && \
+    gem install multi_json -v 1.15.0 && \
     gem install fpm-cookery -v 0.37.0 --no-document && \
     apt-get install -y uuid-runtime && \
     apt-get clean


### PR DESCRIPTION
install multi_json:1.15.0 explicitly, later versions drop support for ruby 2.x

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

